### PR TITLE
Fix image folder creation

### DIFF
--- a/application/app.py
+++ b/application/app.py
@@ -251,10 +251,11 @@ class MainGUI(QtGui.QMainWindow):
         images_folder = os.path.join(ac.CURRENT_PROJECT_PATH, "final_images")
         videos_folder = os.path.join(ac.CURRENT_PROJECT_PATH, "final_videos")
 
-        # Make the videos folder if it doesn't exists 
-        # (images_folder will be created by move_images_to_project_dir_folder)
+        # Make the videos and images folder if it doesn't exists 
         if not os.path.exists(videos_folder):
             os.makedirs(videos_folder)
+        if not os.path.exists(images_folder):
+            os.makedirs(images_folder)
         db_path = os.path.join(ac.CURRENT_PROJECT_PATH, "run", "results.sqlite")
         self.delete_videos("final_videos")
 


### PR DESCRIPTION
I think I ran into an issue where the images folder wasn't created, which meant that images couldn't be moved into the folder, so the video creation failed. This fixes that if an `images_folder` hasn't been created before.