### PR TITLE
Remove framerate field from GUI

### DIFF
--- a/application/app.py
+++ b/application/app.py
@@ -431,12 +431,14 @@ class configGui_features(QtGui.QWidget):
             update_config_with_sections(config_path, "config", "min-feature-time", min_feature_time)
         else: min_feature_time = None
 
-        configFiles(get_config_with_sections(get_config_path(), 'info', 'identifier'),\
-                    max_features_per_frame = max_nfeatures,\
-                    num_displacement_frames = ndisplacements,\
-                    min_feature_displacement = min_feature_displacement,\
-                    max_iterations_to_persist = max_number_iterations,\
-                    min_feature_frames = min_feature_time):
+        
+        # TODO: cannot call self.api.configFiles here. So uncomment this when its possible
+        # configFiles(get_config_with_sections(get_config_path(), 'info', 'identifier'),\
+        #             max_features_per_frame = max_nfeatures,\
+        #             num_displacement_frames = ndisplacements,\
+        #             min_feature_displacement = min_feature_displacement,\
+        #             max_iterations_to_persist = max_number_iterations,\
+        #             min_feature_frames = min_feature_time)
 
     def loadConfig_features(self):
         config_path = get_config_path()
@@ -547,9 +549,10 @@ class configGui_object(QtGui.QWidget):
             update_config_with_sections(config_path, "config", "mm-segmentation-distance", mm_segmentation_distance)
         else: mm_segmentation_distance = None
 
-        configFiles(get_config_with_sections(get_config_path(), 'info', 'identifier'),\
-                    max_connection_distance = mm_connection_distance,\
-                    max_segmentation_distance = mm_segmentation_distance):
+        # TODO: cannot call self.api.configFiles here. So uncomment this when its possible
+        # configFiles(get_config_with_sections(get_config_path(), 'info', 'identifier'),\
+        #             max_connection_distance = mm_connection_distance,\
+        #             max_segmentation_distance = mm_segmentation_distance)
 
     def loadConfig_objects(self):
         config_path = get_config_path()

--- a/application/new_project.py
+++ b/application/new_project.py
@@ -2,8 +2,7 @@
 
 # Form implementation generated from reading ui file 'new_project.ui'
 #
-# Created: Thu Apr  7 07:08:52 2016
-#      by: PyQt4 UI code generator 4.10.4
+# Created by: PyQt4 UI code generator 4.11.4
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -101,12 +100,6 @@ class Ui_create_new_project(object):
         self.newp_video_start_time_input = QtGui.QDateTimeEdit(self.newp_p2)
         self.newp_video_start_time_input.setObjectName(_fromUtf8("newp_video_start_time_input"))
         self.newp_p2_video_layout.setWidget(1, QtGui.QFormLayout.FieldRole, self.newp_video_start_time_input)
-        self.newp_video_fps_label = QtGui.QLabel(self.newp_p2)
-        self.newp_video_fps_label.setObjectName(_fromUtf8("newp_video_fps_label"))
-        self.newp_p2_video_layout.setWidget(2, QtGui.QFormLayout.LabelRole, self.newp_video_fps_label)
-        self.newp_video_fps_input = QtGui.QLineEdit(self.newp_p2)
-        self.newp_video_fps_input.setObjectName(_fromUtf8("newp_video_fps_input"))
-        self.newp_p2_video_layout.setWidget(2, QtGui.QFormLayout.FieldRole, self.newp_video_fps_input)
         self.verticalLayout_2.addLayout(self.newp_p2_video_layout)
         self.newp_add_aerial_image_title = QtGui.QLabel(self.newp_p2)
         font = QtGui.QFont()
@@ -175,11 +168,10 @@ class Ui_create_new_project(object):
         self.newp_p1_title.setText(_translate("create_new_project", "New Safety Project", None))
         self.newp_projectname_label.setText(_translate("create_new_project", "Project Name", None))
         self.newp_p2_add_video_title.setText(_translate("create_new_project", "Add project video", None))
-        self.newp_p2_add_vido_description.setText(_translate("create_new_project", "Browse and select a video file to analyze. Please also input the date and time when the video recording began as well as the framerate of the video in frames per second.", None))
+        self.newp_p2_add_vido_description.setText(_translate("create_new_project", "Browse and select a video file to analyze. Please also input the date and time when the video recording began", None))
         self.newp_video_label.setText(_translate("create_new_project", "Selected video", None))
         self.newp_video_browse.setText(_translate("create_new_project", "Browse...", None))
         self.newp_video_start_time_label.setText(_translate("create_new_project", "Recording start time", None))
-        self.newp_video_fps_label.setText(_translate("create_new_project", "Video framerate", None))
         self.newp_add_aerial_image_title.setText(_translate("create_new_project", "Add aerial image", None))
         self.newp_p2_add_aerial_image_description.setText(_translate("create_new_project", "Browse and select an aerial image of the video\'s target. ", None))
         self.newp_aerial_image_label.setText(_translate("create_new_project", "Aerial image", None))

--- a/application/new_project.ui
+++ b/application/new_project.ui
@@ -96,7 +96,7 @@
     <item>
      <widget class="QLabel" name="newp_p2_add_vido_description">
       <property name="text">
-       <string>Browse and select a video file to analyze. Please also input the date and time when the video recording began as well as the framerate of the video in frames per second.</string>
+       <string>Browse and select a video file to analyze. Please also input the date and time when the video recording began</string>
       </property>
       <property name="wordWrap">
        <bool>true</bool>
@@ -138,16 +138,6 @@
       </item>
       <item row="1" column="1">
        <widget class="QDateTimeEdit" name="newp_video_start_time_input"/>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="newp_video_fps_label">
-        <property name="text">
-         <string>Video framerate</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLineEdit" name="newp_video_fps_input"/>
       </item>
      </layout>
     </item>

--- a/application/pm.py
+++ b/application/pm.py
@@ -43,7 +43,6 @@ class ProjectWizard(QtGui.QWizard):
 
         self.ui.newp_p2.registerField("video_path*", self.ui.newp_video_input)
         self.ui.newp_p2.registerField("video_start_datetime", self.ui.newp_video_start_time_input)
-        self.ui.newp_p2.registerField("video_fps*", self.ui.newp_video_fps_input)
 
         self.ui.newp_p2.registerField("aerial_image*", self.ui.newp_aerial_image_input)
 
@@ -161,7 +160,6 @@ class ProjectWizard(QtGui.QWizard):
         video_extension = self.videopath.split('.')[-1]
         self.config_parser.set("video", "name", 'video.'+video_extension)
         self.config_parser.set("video", "source", self.videopath)
-        self.config_parser.set("video", "framerate", str(self.ui.newp_video_fps_input.text()))
         self.config_parser.set("video", "start", video_timestamp)
 
         with open(os.path.join(get_config_path()), 'wb') as configfile:


### PR DESCRIPTION
Summary:
Removed any instance of framerate in the UI and config file, since
FPS is being calculated implicitly by the server.

In app.py, I commented out lines that called CloudWizard.configFiles
since, it was throwing a syntax error which did not allow me to run app.py

Tested: I got a screenshot of the new UI without framerate, farmerate is
not created in the config.cfg file, and I searched for all other instances of
video_fps and delted them from the repo.

![remove_framerate](https://cloud.githubusercontent.com/assets/5459644/22650711/65c7224c-ec4e-11e6-886d-ff442c6e7c85.png)

