### PR TITLE
Homography/Results images fit in view

### DIFF
--- a/application/custom/homography.py
+++ b/application/custom/homography.py
@@ -24,10 +24,12 @@ class HomographyView(QtGui.QGraphicsView):
         """
         self.scene_image = image
         new_scene = HomographyScene(self)
-        pmap = new_scene.addPixmap(QtGui.QPixmap().fromImage(image))
-        new_scene.register_pixmap(pmap)
+        pmap = QtGui.QPixmap().fromImage(image)
+        pmapitem = new_scene.addPixmap(pmap)
+        new_scene.register_pixmap(pmapitem)
         new_scene.setBackgroundBrush(QtGui.QBrush(QtGui.QColor(0, 0, 0)))
         self.setScene(new_scene)
+        self.fitInView(0, 0, pmap.width(), pmap.height(), Qt.KeepAspectRatio)
         self.show()
         self.image_loaded = True
 
@@ -76,9 +78,11 @@ class HomographyResultView(QtGui.QGraphicsView):
         """
         self.scene_image = image
         new_scene = QtGui.QGraphicsScene(self)
-        pmap = new_scene.addPixmap(QtGui.QPixmap().fromImage(image))
+        pmap = QtGui.QPixmap().fromImage(image)
+        pmapitem = new_scene.addPixmap(pmap)
         new_scene.setBackgroundBrush(QtGui.QBrush(QtGui.QColor(0, 0, 0)))
         self.setScene(new_scene)
+        self.fitInView(0, 0, pmap.width(), pmap.height(), Qt.KeepAspectRatio)
         self.show()
         self.image_loaded = True
 

--- a/application/custom/zoomslider.py
+++ b/application/custom/zoomslider.py
@@ -1,6 +1,7 @@
 # zoomslider.py
 from PyQt4 import QtGui
 
+slider_start = 50.
 
 class ZoomSlider(QtGui.QSlider):
     """Slider used for zooming a HomographyView or a HomographyResultView.
@@ -15,13 +16,13 @@ class ZoomSlider(QtGui.QSlider):
 
     def valueChanged_handler(self):
         if self.zoom_target is None:
-            self.setValue(100)  # If no target set, do not manipulate slider.
+            self.setValue(slider_start)  # If no target set, do not manipulate slider.
             return
         elif not self.zoom_target.image_loaded:
-            self.setValue(100)
+            self.setValue(slider_start)
             return
         slider_val = self.value()
-        desired_percentage = slider_val / 100.
+        desired_percentage = slider_val / slider_start 
         scale = desired_percentage / self.zoom_percentage
         self.zoom_percentage = desired_percentage
         self.zoom_target.scale(scale, scale)


### PR DESCRIPTION
Summary: The images in the 3 image panels are zoomed out to the right
ammount to fit in view upon startup. Adjusted the starting zoom factor
to account for this. Max zoom was increased by a factor of 2!

This is what it looks like by default now, without playing with zoom sliders
<img width="1280" alt="screen shot 2017-02-16 at 12 29 22 pm" src="https://cloud.githubusercontent.com/assets/5459644/23076811/e2d2df28-f50f-11e6-875f-4cce3e276351.png">

And this is part of it fully zoomed in
<img width="1280" alt="screen shot 2017-02-16 at 12 30 02 pm" src="https://cloud.githubusercontent.com/assets/5459644/23076831/f0e5aa32-f50f-11e6-8d8f-b9911b50a059.png">
