### PR TITLE
Info Buttons to Describe config params

### DIFF
--- a/application/message_helper.py
+++ b/application/message_helper.py
@@ -20,5 +20,6 @@ class MessageHelper(QtGui.QDialog):
 
     def show_message(self, message):
         self.ui.label.setText(message)
+        self.adjustSize()
         self.show()
 

--- a/application/views/message_dialog.py
+++ b/application/views/message_dialog.py
@@ -2,7 +2,8 @@
 
 # Form implementation generated from reading ui file 'message_dialog.ui'
 #
-# Created by: PyQt4 UI code generator 4.11.4
+# Created: Mon Feb 20 13:11:19 2017
+#      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -25,18 +26,25 @@ except AttributeError:
 class Ui_message_dialog(object):
     def setupUi(self, message_dialog):
         message_dialog.setObjectName(_fromUtf8("message_dialog"))
-        message_dialog.resize(400, 150)
-        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Preferred)
+        message_dialog.resize(400, 292)
+        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Expanding)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
         sizePolicy.setHeightForWidth(message_dialog.sizePolicy().hasHeightForWidth())
         message_dialog.setSizePolicy(sizePolicy)
         message_dialog.setMaximumSize(QtCore.QSize(400, 16777215))
         self.gridLayout = QtGui.QGridLayout(message_dialog)
+        self.gridLayout.setSizeConstraint(QtGui.QLayout.SetFixedSize)
         self.gridLayout.setObjectName(_fromUtf8("gridLayout"))
         self.verticalLayout = QtGui.QVBoxLayout()
+        self.verticalLayout.setSizeConstraint(QtGui.QLayout.SetFixedSize)
         self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
         self.label = QtGui.QLabel(message_dialog)
+        sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Expanding)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.label.sizePolicy().hasHeightForWidth())
+        self.label.setSizePolicy(sizePolicy)
         self.label.setText(_fromUtf8(""))
         self.label.setAlignment(QtCore.Qt.AlignCenter)
         self.label.setWordWrap(True)

--- a/application/views/message_dialog.ui
+++ b/application/views/message_dialog.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>150</height>
+    <height>292</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+   <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -26,10 +26,22 @@
    <string>Message</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
    <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
      <item>
       <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
         <string/>
        </property>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+QtAwesome==0.4.4
+requests==2.12.4
+Image==1.5.5
+Pillow==4.0.0
+PyQt4==4.11.4
+biplist==1.0.1
+cv2==1.0
+cvutils==0.2.4
+matplotlib==2.0.0
+moviepy==0.2.2.13
+numpy==1.12.0
+scipy==0.18.1


### PR DESCRIPTION
Summary:

- Added qtawesome which gives nice font awesome icons like 'fa:info'
- Refactored common functionality to a configGuiWidget class, in which
  configGui_feature and configGui_object inherit
- Added gridRowHelper method to product the labelX, infoX, inputX
  attributes
- Copied descriptions of these parameters from last years SCOPE software
  user guide.
- Increased message_dialog default size, and then resizes according to text
  input.

One of the parameters on the feature config page
<img width="1280" alt="screen shot 2017-02-20 at 4 53 13 pm" src="https://cloud.githubusercontent.com/assets/5459644/23143095/794ceaf0-f78d-11e6-8bc1-8f1e982a1e2e.png">

Parameters for the road user object config page
<img width="1280" alt="screen shot 2017-02-20 at 4 53 25 pm" src="https://cloud.githubusercontent.com/assets/5459644/23143102/8e4bb1ac-f78d-11e6-9a11-3dd53ac14242.png">
