### PR TITLE
Removed identifier passing from uploadVideo()

### DIFF
--- a/application/cloud_api.py
+++ b/application/cloud_api.py
@@ -76,10 +76,11 @@ class CloudWizard:
             #Use a multipartencoder to stream the file data as just data
             m = MultipartEncoder(fields = files)
 
-            # Get file size in MB's and check if it is greater than a 100 MB
-            # We use a 100MB size limit for transitioning to streaming rather
-            # than loading into memory
-            if m.len/(2**20) >= 100:
+            # m.len returns the size of all of the encoded parts in bytes
+            # and 1024*1024 is MB in bytes. As such we can compare the size
+            # of all the files we want to send to a 100MB size limit for 
+            # transitioning to streaming rather than loading into memory
+            if m.len/(1024*1024) >= 100:
                 # We need to set the Content-Type header
                 r = requests.post(\
                     self.server_addr + 'uploadVideo', data = m,\

--- a/application/cloud_api.py
+++ b/application/cloud_api.py
@@ -65,14 +65,12 @@ class CloudWizard:
 # Upload Functions
 ###############################################################################
 
-    def uploadVideo(self,  video_path, identifier = None):
-        print "uploadVideo called with identifier = {}".format(identifier)
+    def uploadVideo(self,  video_path):
+        print "uploadVideo called"
         with open(video_path, 'rb') as video:
             files = {'video' : video}
-            payload = {'identifier': identifier}
             r = requests.post(\
-                self.server_addr + 'uploadVideo',\
-                data = payload, files = files, stream = True)
+                self.server_addr + 'uploadVideo', files = files, stream = True)
         print "Status Code: {}".format(r.status_code)
         print "Response Text: {}".format(r.text)
         print "Response JSON: {}".format(r.json())

--- a/install_conda_deps.sh
+++ b/install_conda_deps.sh
@@ -4,3 +4,4 @@ conda install -n $YOURENVNAME requests=2.13.0
 conda install -n $YOURENVNAME -c menpo opencv=2.4.11
 conda install -n $YOURENVNAME pyqt=5.6.0
 conda install -n $YOURENVNAME qtawesome=0.4.4
+conda install -n $YOURENVNAME -c conda-forge requests-toolbelt=0.7.1


### PR DESCRIPTION
This PR removes the identifier argument from uploadVideo as that functionality is no longer supported. See our [SantosCloud PR](https://github.com/santosfamilyfoundation/SantosCloud/pull/69) for the accompanying server side fix.