### PR TITLE
EDIT: redesign of final project screen

### DIFF
--- a/application/pm.py
+++ b/application/pm.py
@@ -118,7 +118,11 @@ class ProjectWizard(QtWidgets.QWizard):
     def create_project_dir(self):
         ac.CURRENT_PROJECT_NAME = str(self.ui.newp_projectname_input.text())
         progress_bar = self.ui.newp_creation_progress
+        progress_bar.setHidden(False)
         progress_msg = self.ui.newp_creation_status
+        progress_msg.setHidden(False)
+        creation_button = self.ui.newp_start_creation
+        creation_button.setHidden(True)
         directory_names = ["homography", "results"]
         pr_path = get_project_path()
         if not os.path.exists(pr_path):
@@ -127,6 +131,7 @@ class ProjectWizard(QtWidgets.QWizard):
             update_api(server)
 
             progress_msg.setText("Creating project directories...")
+            progress_bar.show()
             for new_dir in directory_names:
                 progress_bar.setValue(progress_bar.value() + 5)
                 os.makedirs(os.path.join(pr_path, new_dir))

--- a/application/views/new_project.py
+++ b/application/views/new_project.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'application/views/new_project.ui'
+# Form implementation generated from reading ui file 'views/new_project.ui'
 #
 # Created by: PyQt5 UI code generator 5.6
 #
@@ -16,7 +16,7 @@ class Ui_create_new_project(object):
         create_new_project.setAutoFillBackground(False)
         create_new_project.setModal(True)
         create_new_project.setWizardStyle(QtWidgets.QWizard.ClassicStyle)
-        create_new_project.setOptions(QtWidgets.QWizard.NoBackButtonOnLastPage|QtWidgets.QWizard.NoBackButtonOnStartPage)
+        create_new_project.setOptions(QtWidgets.QWizard.NoBackButtonOnStartPage)
         self.newp_p1 = QtWidgets.QWizardPage()
         self.newp_p1.setObjectName("newp_p1")
         self.verticalLayout = QtWidgets.QVBoxLayout(self.newp_p1)
@@ -197,14 +197,20 @@ class Ui_create_new_project(object):
         self.line.setFrameShadow(QtWidgets.QFrame.Sunken)
         self.line.setObjectName("line")
         self.verticalLayout_3.addWidget(self.line)
+        self.newp_p3_add_server_description = QtWidgets.QLabel(self.newp_p3)
+        self.newp_p3_add_server_description.setWordWrap(True)
+        self.newp_p3_add_server_description.setObjectName("newp_p3_add_server_description")
+        self.verticalLayout_3.addWidget(self.newp_p3_add_server_description)
+        self.newp_creation_progress = QtWidgets.QProgressBar(self.newp_p3)
+        self.newp_creation_progress.setProperty("value", 0)
+        self.newp_creation_progress.setVisible(False)
+        self.newp_creation_progress.setObjectName("newp_creation_progress")
+        self.verticalLayout_3.addWidget(self.newp_creation_progress)
         self.newp_start_creation = QtWidgets.QPushButton(self.newp_p3)
         self.newp_start_creation.setObjectName("newp_start_creation")
         self.verticalLayout_3.addWidget(self.newp_start_creation)
-        self.newp_creation_progress = QtWidgets.QProgressBar(self.newp_p3)
-        self.newp_creation_progress.setProperty("value", 0)
-        self.newp_creation_progress.setObjectName("newp_creation_progress")
-        self.verticalLayout_3.addWidget(self.newp_creation_progress)
         self.newp_creation_status = QtWidgets.QLabel(self.newp_p3)
+        self.newp_creation_status.setVisible(False)
         self.newp_creation_status.setObjectName("newp_creation_status")
         self.verticalLayout_3.addWidget(self.newp_creation_status)
         create_new_project.addPage(self.newp_p3)
@@ -232,7 +238,8 @@ class Ui_create_new_project(object):
         self.newp_p2_add_aerial_image_description.setText(_translate("create_new_project", "Browse and select an aerial image of the video\'s target. "))
         self.newp_aerial_image_label.setText(_translate("create_new_project", "Aerial image"))
         self.newp_aerial_image_browse.setText(_translate("create_new_project", "Browse..."))
-        self.newp_p2_add_video_title_2.setText(_translate("create_new_project", "Creating new project"))
-        self.newp_start_creation.setText(_translate("create_new_project", "Click to create project."))
+        self.newp_p2_add_video_title_2.setText(_translate("create_new_project", "Confirm project settings"))
+        self.newp_p3_add_server_description.setText(_translate("create_new_project", "If complete, create your project. Otherwise, go back to make any necessary changes."))
+        self.newp_start_creation.setText(_translate("create_new_project", "Click to send project to server"))
         self.newp_creation_status.setText(_translate("create_new_project", "Beginning project creation..."))
 

--- a/application/views/new_project.ui
+++ b/application/views/new_project.ui
@@ -24,7 +24,7 @@
    <enum>QWizard::ClassicStyle</enum>
   </property>
   <property name="options">
-   <set>QWizard::NoBackButtonOnLastPage|QWizard::NoBackButtonOnStartPage</set>
+   <set>QWizard::NoBackButtonOnStartPage</set>
   </property>
   <widget class="QWizardPage" name="newp_p1">
    <layout class="QVBoxLayout" name="verticalLayout">
@@ -351,7 +351,7 @@ Input the time when the video recording occurred.</string>
        </font>
       </property>
       <property name="text">
-       <string>Creating new project</string>
+       <string>Confirm project settings</string>
       </property>
      </widget>
     </item>
@@ -363,9 +363,12 @@ Input the time when the video recording occurred.</string>
      </widget>
     </item>
     <item>
-     <widget class="QPushButton" name="newp_start_creation">
+     <widget class="QLabel" name="newp_p3_add_server_description">
       <property name="text">
-       <string>Click to create project.</string>
+       <string>If complete, create your project. Otherwise, go back to make any necessary changes.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
      </widget>
     </item>
@@ -374,12 +377,25 @@ Input the time when the video recording occurred.</string>
       <property name="value">
        <number>0</number>
       </property>
+      <property name="visible">
+        <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QPushButton" name="newp_start_creation">
+      <property name="text">
+       <string>Click to send project to server</string>
+      </property>
      </widget>
     </item>
     <item>
      <widget class="QLabel" name="newp_creation_status">
       <property name="text">
        <string>Beginning project creation...</string>
+      </property>
+      <property name="visible">
+        <bool>false</bool>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
Redesign of final screen. The button to send results to server is still there, but better labelled. Also, the button disappears on click and is replaced by status bar and info about the upload.
<img width="559" alt="screen shot 2017-03-08 at 12 05 39 pm" src="https://cloud.githubusercontent.com/assets/5553994/23714669/16bce72e-03f8-11e7-8854-1f96d8165f98.png">
<img width="565" alt="screen shot 2017-03-08 at 12 05 47 pm" src="https://cloud.githubusercontent.com/assets/5553994/23714671/181c8566-03f8-11e7-89cc-3376c80590cb.png">
