### PR TITLE
Error handling

### DIFF
--- a/application/app.py
+++ b/application/app.py
@@ -143,13 +143,17 @@ class MainGUI(QtWidgets.QMainWindow):
     def test_feature(self):
         frame_start = get_config_with_sections(get_config_path(), "config", "frame_start")
         num_frames = get_config_with_sections(get_config_path(), "config", "num_frames")
-        api.testConfig(get_identifier(),\
+
+        success, error_message = api.testConfig(get_identifier(),\
                             'feature',\
                             frame_start = frame_start,\
                             num_frames = num_frames)
-        StatusPoller(get_identifier(), 'feature_test', 5, self.test_feature_callback).start()
 
-        self.show_message('Your test of feature tracking has begun. When it has completed, a video will be shown in the window on the left. Please wait, this will only take about a minute.')
+        if success:
+            StatusPoller(get_identifier(), 'feature_test', 5, self.test_feature_callback).start()
+            self.show_message('Your test of feature tracking has begun. When it has completed, a video will be shown in the window on the left. Please wait, this will only take about a minute.')
+        else:
+            self.show_message(error_message)
 
     def test_feature_callback(self):
         # Emitting the signal will call get_feature_video on the main thread

--- a/application/message_helper.py
+++ b/application/message_helper.py
@@ -18,8 +18,12 @@ class MessageHelper(QtWidgets.QDialog):
         flags = self.windowFlags() & (~QtCore.Qt.WindowContextHelpButtonHint)
         self.setWindowFlags(flags)
 
-    def show_message(self, message):
+    def show_message(self, message, title=None):
         self.ui.label.setText(message)
+
+        if title is not None:
+            self.setWindowTitle(title)
+
         self.adjustSize()
         self.show()
 

--- a/application/pm.py
+++ b/application/pm.py
@@ -40,6 +40,9 @@ class ProjectWizard(QtWidgets.QWizard):
         # Make 'Back' button non-destructive
         self.setOption(QtWidgets.QWizard.IndependentPages)
 
+        # Don't show 'Cancel' button
+        self.setOption(QtWidgets.QWizard.NoCancelButton)
+
         self.ui.newp_start_creation.clicked.connect(self.start_create_project)
         self.config_parser = SafeConfigParser()
 

--- a/application/pm.py
+++ b/application/pm.py
@@ -60,6 +60,7 @@ class ProjectWizard(QtWidgets.QWizard):
         self.last_known_location = None
 
     def showEvent(self, event):
+        # We want to autofill the default server every time the creation page is shown
         self.ui.newp_video_server_input.setText("http://localhost:8088")
 
     def validateCurrentPage(self):
@@ -233,7 +234,7 @@ class ProjectWizard(QtWidgets.QWizard):
         ac.CURRENT_PROJECT_PATH = None
         self.creating_project = False
         self._update_ui_for_project_creation()
-        self.show_message(error)
+        self.show_message(error, title="Error")
 
         if project_name_to_delete is not None:
             path = os.path.join(get_default_project_dir(), project_name_to_delete)

--- a/application/test_cloud.py
+++ b/application/test_cloud.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     ###########################################################################
     # Upload Video
     ###########################################################################
-    identifier = remote.uploadVideo(VIDEO_PATH)
+    _, _, identifier = remote.uploadVideo(VIDEO_PATH)
     raw_input('Uploading Video, please wait...\n Press Enter to Continue')
 
     ###########################################################################


### PR DESCRIPTION
This PR does a lot of things (sorry!):

- Changes all methods in cloud_api.py to return `(success, error_message, data)` tuple. (`data` is an optional third return value. All return success and error_message, and some return data as a third member in the tuple)
- Handles server not connected errors in all cloud_api.py calls
- Properly handles project creation failures! Shows an error message for the error, and actually allows the user to try again!
- Doesn't destroy form data upon going backward in project creation dialog.

Not included in this PR, but coming soon (requires server changes too, plus this PR is already huge):

- Handling generic errors returned by server (i.e. checking status_code and getting the returned `error_message`.
- Failure messages for StatusPoller events
