### PR TITLE
Results api refactor

### DIFF
--- a/application/app.py
+++ b/application/app.py
@@ -172,7 +172,7 @@ class MainGUI(QtWidgets.QMainWindow):
                 self.feature_tracking_video_player.openFile(video_path)
 
     def get_feature_video(self):
-        success, err = api.getTestConfig(get_identifier(), 'feature', get_project_path())
+        success, err = api.getTestConfig(get_identifier(), 'feature', os.path.join(get_project_path(), 'feature_video'))
         if success:
             self.open_feature_video()
         else:
@@ -208,7 +208,7 @@ class MainGUI(QtWidgets.QMainWindow):
                 self.roadusers_tracking_video_player.openFile(video_path)
 
     def get_object_video(self):
-        success, err = api.getTestConfig(get_identifier(), 'object', get_project_path())
+        success, err = api.getTestConfig(get_identifier(), 'object', os.path.join(get_project_path(), 'object_video'))
         if success:
             self.open_object_video()
         else:
@@ -257,13 +257,12 @@ class MainGUI(QtWidgets.QMainWindow):
             self.error_signal.emit(error_message)
 
     def retrieveResults(self):
-        success, err = api.retrieveResults(get_identifier(), get_project_path())
+        results_dir = os.path.join(get_project_path(), 'results')
+        success, err = api.retrieveResults(get_identifier(), results_dir)
 
         if not success:
             self.show_error(err)
             return
-
-        results_dir = os.path.join(get_project_path(), "results")
 
         with zipfile.ZipFile(os.path.join(results_dir, "results.zip"), "r") as zip_file:
             zip_file.extractall(results_dir)

--- a/application/cloud_api.py
+++ b/application/cloud_api.py
@@ -340,7 +340,7 @@ class CloudWizard:
         payload = {
             'identifier': identifier,
         }
-
+        
         path = os.path.join(file_path, 'results.zip')
         if os.path.exists(path):
             os.remove(path)

--- a/application/cloud_api.py
+++ b/application/cloud_api.py
@@ -399,7 +399,7 @@ class CloudWizard:
         }
 
         try:
-            r = requests.post(self.server_addr + 'highlightVideo', data = payload)
+            r = requests.get(self.server_addr + 'highlightVideo', params = payload, streams = True)
         except requests.exceptions.ConnectionError as e:
             print('Connection is offline')
             return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
@@ -416,7 +416,7 @@ class CloudWizard:
         }
 
         try:
-            r = requests.post(self.server_addr + 'makeReport', data = payload)
+            r = requests.get(self.server_addr + 'makeReport', params  = payload, stream = True)
         except requests.exceptions.ConnectionError as e:
             print('Connection is offline')
             return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
@@ -441,15 +441,16 @@ class CloudWizard:
         payload = {
             'identifier': identifier,
         }
-        path = os.path.join(file_path, 'results.zip')
-        if os.path.exists(path):
-            os.remove(path)
 
         try:
             r = requests.get(self.server_addr + 'retrieveResults', params = payload, stream=True)
         except requests.exceptions.ConnectionError as e:
             print('Connection is offline')
             return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
+
+        path = os.path.join(file_path, 'results.zip')
+        if os.path.exists(path):
+            os.remove(path)
 
         with open(path, 'wb') as f:
             print('Dumping "{0}"...'.format(path))
@@ -468,7 +469,7 @@ class CloudWizard:
         }
 
         try:
-            r = requests.post(self.server_addr + 'roadUserCounts', data = payload)
+            r = requests.get(self.server_addr + 'roadUserCounts', params = payload, stream=True)
         except requests.exceptions.ConnectionError as e:
             print('Connection is offline')
             return (False, 'Connection to server "{}" is offline'.format(self.server_addr))

--- a/application/cloud_api.py
+++ b/application/cloud_api.py
@@ -128,7 +128,7 @@ class CloudWizard:
 
         homography = r.json()['homography']
         if file_path:
-            path = os.path.join(file_path, 'homography', 'homography.txt')
+            path = os.path.join(file_path, 'homography.txt')
             np.savetxt(path, np.array(homography))
         return (True, None, homography)
 
@@ -199,7 +199,7 @@ class CloudWizard:
         print "Response Text: {}".format(r.text)
         return (True, None)
 
-    def getTestConfig(self, identifier, test_flag, project_path):
+    def getTestConfig(self, identifier, test_flag, file_path):
         print "getTestConfig called with identifier = {} and test_flag = {}".format(identifier,test_flag)
 
         payload = {
@@ -208,13 +208,9 @@ class CloudWizard:
         }
 
         if test_flag == 'feature':
-            if not os.path.exists(os.path.join(project_path, 'feature_video')):
-                os.mkdir(os.path.join(project_path, 'feature_video'))
-            path = os.path.join(project_path, 'feature_video', 'feature_video.mp4')
+            path = os.path.join(file_path, 'feature_video.mp4')
         elif test_flag == 'object':
-            if not os.path.exists(os.path.join(project_path, 'object_video')):
-                os.mkdir(os.path.join(project_path, 'object_video'))
-            path = os.path.join(project_path, 'object_video', 'object_video.mp4')
+            path = os.path.join(file_path, 'object_video.mp4')
         else:
             print "ERROR: Invalid flag"
             return
@@ -412,7 +408,7 @@ class CloudWizard:
         print "Response Text: {}".format(r.text)
         return (True, None)
 
-    def makeReport(self, identifier):
+    def makeReport(self, identifier, file_path):
         print "makeReport called with identifier = {}".format(identifier)
 
         payload = {
@@ -425,17 +421,27 @@ class CloudWizard:
             print('Connection is offline')
             return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
 
+        path = os.path.join(file_path, 'santosreport.pdf')
+        if os.path.exists(path):
+            os.remove(path)
+
+        with open(path, 'wb') as f:
+            print('Dumping "{0}"...'.format(path))
+            for chunk in r.iter_content(chunk_size=2048):
+                if chunk:
+                    f.write(chunk)
+
         print "Status Code: {}".format(r.status_code)
         print "Response Text: {}".format(r.text)
         return (True, None)
 
-    def retrieveResults(self, identifier, project_path):
+    def retrieveResults(self, identifier, file_path):
         print "retrieveResults called with identifier = {}".format(identifier)
 
         payload = {
             'identifier': identifier,
         }
-        path = os.path.join(project_path, 'results', 'results.zip')
+        path = os.path.join(file_path, 'results.zip')
         if os.path.exists(path):
             os.remove(path)
 
@@ -454,7 +460,7 @@ class CloudWizard:
         print "Status Code: {}".format(r.status_code)
         return (True, None)
 
-    def roadUserCounts(self, identifier):
+    def roadUserCounts(self, identifier, file_path):
         print "roadUserCounts called with identifier = {}".format(identifier)
 
         payload = {
@@ -467,11 +473,21 @@ class CloudWizard:
             print('Connection is offline')
             return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
 
+        path = os.path.join(file_path, 'road_user_icon_counts.jpg')
+        if os.path.exists(path):
+            os.remove(path)
+
+        with open(path, 'wb') as f:
+            print('Dumping "{0}"...'.format(path))
+            for chunk in r.iter_content(chunk_size=2048):
+                if chunk:
+                    f.write(chunk)
+
         print "Status Code: {}".format(r.status_code)
         print "Response Text: {}".format(r.text)
         return (True, None)
 
-    def speedDistribution(self, identifier, speed_limit = None, vehicle_only = None):
+    def speedDistribution(self, identifier, file_path, speed_limit = None, vehicle_only = None):
         print "speedDistribution called with identifier = {}, speed_limit = {} and vehicle_only = {}"\
                 .format(identifier, speed_limit, vehicle_only)
 
@@ -487,11 +503,19 @@ class CloudWizard:
             print('Connection is offline')
             return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
 
+        path = os.path.join(file_path, 'velocityPDF.jpg')
+        if os.path.exists(path):
+            os.remove(path)
+
+        with open(path, 'wb') as f:
+            print('Dumping "{0}"...'.format(path))
+            for chunk in r.iter_content(chunk_size=2048):
+                if chunk:
+                    f.write(chunk)
+
         print "Status Code: {}".format(r.status_code)
         print "Response Text: {}".format(r.text)
         return (True, None)
-
-
 
 ###############################################################################
 # Helper Methods

--- a/application/cloud_api.py
+++ b/application/cloud_api.py
@@ -556,6 +556,10 @@ class CloudWizard:
             print('Connection is offline')
             return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
 
+        success, err = self.parse_error(r)
+        if not success:
+            return (success, err)
+
         path = os.path.join(file_path, 'road_user_icon_counts.jpg')
         if os.path.exists(path):
             os.remove(path)

--- a/application/cloud_api.py
+++ b/application/cloud_api.py
@@ -103,7 +103,7 @@ class CloudWizard:
         print "Status Code: {}".format(r.status_code)
         homography = r.json()['homography']
         if file_path:
-            path = os.path.join(file_path, 'homography', 'homography.txt')
+            path = os.path.join(file_path, 'homography.txt')
             np.savetxt(path, np.array(homography))
         return homography
 
@@ -159,7 +159,7 @@ class CloudWizard:
         print "Status Code: {}".format(r.status_code)
         print "Response Text: {}".format(r.text)
 
-    def getTestConfig(self, identifier, test_flag, project_path):
+    def getTestConfig(self, identifier, test_flag, file_path):
         print "getTestConfig called with identifier = {} and test_flag = {}".format(identifier,test_flag)
 
         payload = {
@@ -168,13 +168,9 @@ class CloudWizard:
         }
 
         if test_flag == 'feature':
-            if not os.path.exists(os.path.join(project_path, 'feature_video')):
-                os.mkdir(os.path.join(project_path, 'feature_video'))
-            path = os.path.join(project_path, 'feature_video', 'feature_video.mp4')
+            path = os.path.join(file_path, 'feature_video.mp4')
         elif test_flag == 'object':
-            if not os.path.exists(os.path.join(project_path, 'object_video')):
-                os.mkdir(os.path.join(project_path, 'object_video'))
-            path = os.path.join(project_path, 'object_video', 'object_video.mp4')
+            path = os.path.join(file_path, 'object_video.mp4')
         else:
             print "ERROR: Invalid flag"
             return
@@ -304,30 +300,51 @@ class CloudWizard:
             'vehicle_only': vehicle_only
         }
 
-        r = requests.post(self.server_addr + 'highlightVideo', data = payload)
+        try:
+            r = requests.get(self.server_addr + 'highlightVideo', params = payload)
+        except requests.exceptions.ConnectionError as e:
+            print('Connection is offline')
+            return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
+
         print "Status Code: {}".format(r.status_code)
         print "Response Text: {}".format(r.text)
 
-    def makeReport(self, identifier):
+    def makeReport(self, identifier, file_path):
         print "makeReport called with identifier = {}".format(identifier)
 
         payload = {
             'identifier': identifier,
         }
 
-        r = requests.post(self.server_addr + 'makeReport', data = payload)
-        print "Status Code: {}".format(r.status_code)
-        print "Response Text: {}".format(r.text)
+        try:
+            r = requests.get(self.server_addr + 'makeReport', params  = payload)
+        except requests.exceptions.ConnectionError as e:
+            print('Connection is offline')
+            return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
 
-    def retrieveResults(self, identifier, project_path):
+        path = os.path.join(file_path, 'santosreport.pdf')
+        if os.path.exists(path):
+            os.remove(path)
+
+        with open(path, 'wb') as f:
+            print('Dumping "{0}"...'.format(path))
+            for chunk in r.iter_content(chunk_size=2048):
+                if chunk:
+                    f.write(chunk)
+
+        print "Status Code: {}".format(r.status_code)
+
+    def retrieveResults(self, identifier, file_path):
         print "retrieveResults called with identifier = {}".format(identifier)
 
         payload = {
             'identifier': identifier,
         }
-        path = os.path.join(project_path, 'results', 'results.zip')
+
+        path = os.path.join(file_path, 'results.zip')
         if os.path.exists(path):
             os.remove(path)
+
         r = requests.get(self.server_addr + 'retrieveResults', params = payload, stream=True)
         with open(path, 'wb') as f:
             print('Dumping "{0}"...'.format(path))
@@ -336,18 +353,32 @@ class CloudWizard:
                     f.write(chunk)
         print "Status Code: {}".format(r.status_code)
 
-    def roadUserCounts(self, identifier):
+    def roadUserCounts(self, identifier, file_path):
         print "roadUserCounts called with identifier = {}".format(identifier)
 
         payload = {
             'identifier': identifier,
         }
 
-        r = requests.post(self.server_addr + 'roadUserCounts', data = payload)
-        print "Status Code: {}".format(r.status_code)
-        print "Response Text: {}".format(r.text)
+        try:
+            r = requests.get(self.server_addr + 'roadUserCounts', params = payload, stream=True)
+        except requests.exceptions.ConnectionError as e:
+            print('Connection is offline')
+            return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
 
-    def speedDistribution(self, identifier, speed_limit = None, vehicle_only = None):
+        path = os.path.join(file_path, 'road_user_icon_counts.jpg')
+        if os.path.exists(path):
+            os.remove(path)
+
+        with open(path, 'wb') as f:
+            print('Dumping "{0}"...'.format(path))
+            for chunk in r.iter_content(chunk_size=2048):
+                if chunk:
+                    f.write(chunk)
+
+        print "Status Code: {}".format(r.status_code)
+
+    def speedDistribution(self, identifier, file_path, speed_limit = None, vehicle_only = None):
         print "speedDistribution called with identifier = {}, speed_limit = {} and vehicle_only = {}"\
                 .format(identifier, speed_limit, vehicle_only)
 
@@ -357,11 +388,25 @@ class CloudWizard:
             'vehicle_only': vehicle_only
         }
 
-        r = requests.post(self.server_addr + 'speedDistribution', data = payload)
+        try:
+            r = requests.get(self.server_addr + 'speedDistribution', params = payload, stream=True)
+        except requests.exceptions.ConnectionError as e:
+            print('Connection is offline')
+            return (False, 'Connection to server "{}" is offline'.format(self.server_addr))
+
+        path = os.path.join(file_path, 'velocityPDF.jpg')
+        if os.path.exists(path):
+            os.remove(path)
+
+        with open(path, 'wb') as f:
+            print('Dumping "{0}"...'.format(path))
+            for chunk in r.iter_content(chunk_size=2048):
+                if chunk:
+                    f.write(chunk)
+
         print "Status Code: {}".format(r.status_code)
         print "Response Text: {}".format(r.text)
-
-
+        return (True, None)
 
 ###############################################################################
 # Helper Methods

--- a/application/cloud_api.py
+++ b/application/cloud_api.py
@@ -103,7 +103,7 @@ class CloudWizard:
         print "Status Code: {}".format(r.status_code)
         homography = r.json()['homography']
         if file_path:
-            path = os.path.join(file_path, 'homography', 'homography.txt')
+            path = os.path.join(file_path, 'homography.txt')
             np.savetxt(path, np.array(homography))
         return homography
 
@@ -159,7 +159,7 @@ class CloudWizard:
         print "Status Code: {}".format(r.status_code)
         print "Response Text: {}".format(r.text)
 
-    def getTestConfig(self, identifier, test_flag, project_path):
+    def getTestConfig(self, identifier, test_flag, file_path):
         print "getTestConfig called with identifier = {} and test_flag = {}".format(identifier,test_flag)
 
         payload = {
@@ -168,13 +168,9 @@ class CloudWizard:
         }
 
         if test_flag == 'feature':
-            if not os.path.exists(os.path.join(project_path, 'feature_video')):
-                os.mkdir(os.path.join(project_path, 'feature_video'))
-            path = os.path.join(project_path, 'feature_video', 'feature_video.mp4')
+            path = os.path.join(file_path, 'feature_video.mp4')
         elif test_flag == 'object':
-            if not os.path.exists(os.path.join(project_path, 'object_video')):
-                os.mkdir(os.path.join(project_path, 'object_video'))
-            path = os.path.join(project_path, 'object_video', 'object_video.mp4')
+            path = os.path.join(file_path, 'object_video.mp4')
         else:
             print "ERROR: Invalid flag"
             return
@@ -304,28 +300,36 @@ class CloudWizard:
             'vehicle_only': vehicle_only
         }
 
-        r = requests.post(self.server_addr + 'highlightVideo', data = payload)
+        r = requests.get(self.server_addr + 'highlightVideo', params = payload)
         print "Status Code: {}".format(r.status_code)
         print "Response Text: {}".format(r.text)
 
-    def makeReport(self, identifier):
+    def makeReport(self, identifier, file_path):
         print "makeReport called with identifier = {}".format(identifier)
 
         payload = {
             'identifier': identifier,
         }
 
-        r = requests.post(self.server_addr + 'makeReport', data = payload)
-        print "Status Code: {}".format(r.status_code)
-        print "Response Text: {}".format(r.text)
+        r = requests.get(self.server_addr + 'makeReport', params  = payload)
+        path = os.path.join(file_path, 'santosreport.pdf')
+        if os.path.exists(path):
+            os.remove(path)
 
-    def retrieveResults(self, identifier, project_path):
+        with open(path, 'wb') as f:
+            print('Dumping "{0}"...'.format(path))
+            for chunk in r.iter_content(chunk_size=2048):
+                if chunk:
+                    f.write(chunk)
+        print "Status Code: {}".format(r.status_code)
+
+    def retrieveResults(self, identifier, file_path):
         print "retrieveResults called with identifier = {}".format(identifier)
 
         payload = {
             'identifier': identifier,
         }
-        path = os.path.join(project_path, 'results', 'results.zip')
+        path = os.path.join(file_path, 'results.zip')
         if os.path.exists(path):
             os.remove(path)
         r = requests.get(self.server_addr + 'retrieveResults', params = payload, stream=True)
@@ -336,18 +340,25 @@ class CloudWizard:
                     f.write(chunk)
         print "Status Code: {}".format(r.status_code)
 
-    def roadUserCounts(self, identifier):
+    def roadUserCounts(self, identifier, file_path):
         print "roadUserCounts called with identifier = {}".format(identifier)
 
         payload = {
             'identifier': identifier,
         }
 
-        r = requests.post(self.server_addr + 'roadUserCounts', data = payload)
+        r = requests.get(self.server_addr + 'roadUserCounts', params = payload, stream=True)
+        path = os.path.join(file_path, 'road_user_icon_counts.jpg')
+        if os.path.exists(path):
+            os.remove(path)
+        with open(path, 'wb') as f:
+            print('Dumping "{0}"...'.format(path))
+            for chunk in r.iter_content(chunk_size=2048):
+                if chunk:
+                    f.write(chunk)
         print "Status Code: {}".format(r.status_code)
-        print "Response Text: {}".format(r.text)
 
-    def speedDistribution(self, identifier, speed_limit = None, vehicle_only = None):
+    def speedDistribution(self, identifier, file_path, speed_limit = None, vehicle_only = None):
         print "speedDistribution called with identifier = {}, speed_limit = {} and vehicle_only = {}"\
                 .format(identifier, speed_limit, vehicle_only)
 
@@ -357,11 +368,16 @@ class CloudWizard:
             'vehicle_only': vehicle_only
         }
 
-        r = requests.post(self.server_addr + 'speedDistribution', data = payload)
+        r = requests.get(self.server_addr + 'speedDistribution', params = payload, stream=True)
+        path = os.path.join(file_path, 'velocityPDF.jpg')
+        if os.path.exists(path):
+            os.remove(path)
+        with open(path, 'wb') as f:
+            print('Dumping "{0}"...'.format(path))
+            for chunk in r.iter_content(chunk_size=2048):
+                if chunk:
+                    f.write(chunk)
         print "Status Code: {}".format(r.status_code)
-        print "Response Text: {}".format(r.text)
-
-
 
 ###############################################################################
 # Helper Methods

--- a/application/cloud_api.py
+++ b/application/cloud_api.py
@@ -441,7 +441,7 @@ class CloudWizard:
         payload = {
             'identifier': identifier,
         }
-
+        
         try:
             r = requests.get(self.server_addr + 'retrieveResults', params = payload, stream=True)
         except requests.exceptions.ConnectionError as e:


### PR DESCRIPTION
This PR modifies the results API to use GET instead of POST.

They also now take a file_path instead of a project_path in order to make the API more friendly to developers who do not want to use our arbitrary file project structure. More forward facing work can now be done that the files are returned back in individual functions instead of one zip file being sent at the conclusion. See [this PR](https://github.com/santosfamilyfoundation/SantosCloud/pull/86) on SantosCloud for corresponding changes.