### PR TITLE
Use right delimiters on Windows

### DIFF
--- a/application/app.py
+++ b/application/app.py
@@ -24,6 +24,7 @@ import project_selector
 from cloud_api import api
 from cloud_api import StatusPoller
 from video import convert_video_to_frames
+from utils.path_replacer import replace_path_delimiters
 
 
 class MainGUI(QtWidgets.QMainWindow):
@@ -274,7 +275,7 @@ class MainGUI(QtWidgets.QMainWindow):
         if sys.platform == 'darwin':
             subprocess.Popen(['open', '--', results_dir])
         elif sys.platform == 'linux2':
-            subprocess.Popen(['xdg-open', '--', results_dir])
+            subprocess.Popen(['xdg-open', results_dir])
         elif sys.platform == 'win32':
             subprocess.Popen(['explorer', results_dir])
 
@@ -306,6 +307,7 @@ class MainGUI(QtWidgets.QMainWindow):
 
     def open_project(self):
         fname = str(QtWidgets.QFileDialog.getExistingDirectory(self, "Open Existing Project Folder...", get_default_project_dir()))
+        fname = replace_path_delimiters(fname)
         # TODO: Instead of select folder, perhaps select config file?
         if fname:
             pm.load_project(fname, self)

--- a/application/utils/path_replacer.py
+++ b/application/utils/path_replacer.py
@@ -1,0 +1,6 @@
+
+def replace_path_delimiters(path):
+	from os import sep
+	p = path.replace('\\', '/').replace('//', '/').split('/')
+	return sep.join(p)
+


### PR DESCRIPTION
Fixes #66 and #84. 

The fix for #84 involves using the right delimeter on Windows. For some reason, the command line call to `explorer` doesn't like mixed delimiters.

The fix for #66 is just to not use `--` as extra arguments for `xdg-open`.