### PR TITLE
FIX: homography result view zoom when recompute

### DIFF
--- a/application/app.py
+++ b/application/app.py
@@ -474,6 +474,8 @@ class MainGUI(QtWidgets.QMainWindow):
         worldImg.save(aerial_goodness_path)  # Save aerial goodness image
         videoImg.save(camera_goodness_path)  # Save camera goodness image
 
+        # Set Slider Zoom Position to Default when Loading in the Result Image
+        self.ui.homography_hslider_zoom_computed_image.resetSliderPosition()
         self.ui.homography_results.load_image(QtGui.QImage(aerial_goodness_path))  # Load aerial goodness image into gui
 
 ##########################################################################################################################

--- a/application/custom/zoomslider.py
+++ b/application/custom/zoomslider.py
@@ -1,11 +1,11 @@
 # zoomslider.py
 from PyQt5 import QtWidgets
 
-slider_start = 50.
 
 class ZoomSlider(QtWidgets.QSlider):
     """Slider used for zooming a HomographyView or a HomographyResultView.
     """
+    slider_start = 50.
     def __init__(self, parent):
         super(ZoomSlider, self).__init__(parent)
         self.zoom_target = None  # QGraphicsView
@@ -16,13 +16,18 @@ class ZoomSlider(QtWidgets.QSlider):
 
     def valueChanged_handler(self):
         if self.zoom_target is None:
-            self.setValue(slider_start)  # If no target set, do not manipulate slider.
+            # self.setValue(self.slider_start)  # If no target set, do not manipulate slider.
+            self.resetSliderPosition()
             return
         elif not self.zoom_target.image_loaded:
-            self.setValue(slider_start)
+            # self.setValue(self.slider_start)
+            self.resetSliderPosition()
             return
         slider_val = self.value()
-        desired_percentage = slider_val / slider_start 
+        desired_percentage = slider_val / self.slider_start 
         scale = desired_percentage / self.zoom_percentage
         self.zoom_percentage = desired_percentage
         self.zoom_target.scale(scale, scale)
+
+    def resetSliderPosition(self):
+        self.setValue(self.slider_start)

--- a/application/custom/zoomslider.py
+++ b/application/custom/zoomslider.py
@@ -16,11 +16,9 @@ class ZoomSlider(QtWidgets.QSlider):
 
     def valueChanged_handler(self):
         if self.zoom_target is None:
-            # self.setValue(self.slider_start)  # If no target set, do not manipulate slider.
-            self.resetSliderPosition()
+            self.resetSliderPosition()  # If no target set, do not manipulate slider.
             return
         elif not self.zoom_target.image_loaded:
-            # self.setValue(self.slider_start)
             self.resetSliderPosition()
             return
         slider_val = self.value()


### PR DESCRIPTION
Summary:
Fixes #80

Test:
1. Zoom in on the homography results image
2. Compute Homography
3. The image should be displayed with default zoom, instead of breaking
the zoom scale